### PR TITLE
Remove 'contact' document type from 'guidance and regulation' supergroup

### DIFF
--- a/data/supertypes.yml
+++ b/data/supertypes.yml
@@ -539,7 +539,6 @@ content_purpose_supergroup:
         - manual_section
         - guidance
         - map
-        - contact
         - calendar
         - statutory_guidance
         - notice


### PR DESCRIPTION
Remove document type `contact` from `guidance_and_regulation` `content_purpose_supergroup`